### PR TITLE
Support addons

### DIFF
--- a/lib/build-config-editor.js
+++ b/lib/build-config-editor.js
@@ -26,7 +26,8 @@ function findInlineConfigNode(ast) {
     visitNewExpression: function (path) {
       var node = path.node;
 
-      if (node.callee.name === 'EmberApp') {
+      if (node.callee.name === 'EmberApp'
+          || node.callee.name === 'EmberAddon') {
         configNode = node.arguments.find(isObjectExpression);
 
         return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-build-config-editor",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Utility for ember blueprints to use to modify ember-cli-build.js",
   "main": "index.js",
   "files": [

--- a/tests/build-config-editor-test.js
+++ b/tests/build-config-editor-test.js
@@ -117,6 +117,20 @@ describe('Adds inline configuration', function () {
 
     astEquality(newBuild.code(), source);
   });
+
+  it('adds a key with properties to an empty addon configuration', function () {
+    var source = readFixture('default-addon.js');
+
+    var build = new EmberBuildConfigEditor(source);
+
+    var newBuild = build.edit('some-addon', {
+      booleanProperty: false,
+      numericProperty: 17,
+      stringProperty: 'wow'
+    });
+
+    astEquality(newBuild.code(), readFixture('single-config-block-addon.js'));
+  });
 });
 
 describe('Adds separate configuration', function() {

--- a/tests/fixtures/default-addon.js
+++ b/tests/fixtures/default-addon.js
@@ -1,0 +1,18 @@
+/*jshint node:true*/
+/* global require, module */
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function(defaults) {
+  var app = new EmberAddon(defaults, {
+    // Add options here
+  });
+
+  /*
+   This build file specifies the options for the dummy test app of this
+   addon, located in `/tests/dummy`
+   This build file does *not* influence how the addon or the app using it
+   behave. You most likely want to be modifying `./index.js` or app's build fil
+   */
+
+  return app.toTree();
+};

--- a/tests/fixtures/single-config-block-addon.js
+++ b/tests/fixtures/single-config-block-addon.js
@@ -1,0 +1,23 @@
+/*jshint node:true*/
+/* global require, module */
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function(defaults) {
+  var app = new EmberAddon(defaults, {
+    // Add options here
+    'some-addon': {
+      'booleanProperty': false,
+      'numericProperty': 17,
+      'stringProperty': 'wow'
+    }
+  });
+
+  /*
+   This build file specifies the options for the dummy test app of this
+   addon, located in `/tests/dummy`
+   This build file does *not* influence how the addon or the app using it
+   behave. You most likely want to be modifying `./index.js` or app's build fil
+   */
+
+  return app.toTree();
+};


### PR DESCRIPTION
Fixes #8.

Support `EmberAddon` when finding the configuration block.