### PR TITLE
Fix editing of separate config property in an addon

### DIFF
--- a/lib/build-config-editor.js
+++ b/lib/build-config-editor.js
@@ -55,7 +55,8 @@ function findSeparateConfigNode(ast) {
     visitNewExpression: function(path) {
       var node = path.node;
 
-      if (node.callee.name === 'EmberApp') {
+      if (node.callee.name === 'EmberApp'
+          || node.callee.name === 'EmberAddon') {
         configIdentifier = node.arguments[1];
         configPath = path;
 

--- a/tests/build-config-editor-test.js
+++ b/tests/build-config-editor-test.js
@@ -147,6 +147,20 @@ describe('Adds separate configuration', function() {
 
     astEquality(newBuild.code(), readFixture('separate-config-block-different-values.js'));
   });
+
+  it('edits a non-inline config in an addon configuration', function() {
+    var source = readFixture('separate-config-block-addon.js');
+
+    var build = new EmberBuildConfigEditor(source);
+
+    var newBuild = build.edit('some-addon', {
+      booleanProperty: true,
+      numericProperty: 42,
+      stringProperty: 'amazing'
+    });
+
+    astEquality(newBuild.code(), readFixture('separate-config-block-different-values-addon.js'));
+  });
 });
 
 describe('Handles missing configuration', function() {

--- a/tests/fixtures/separate-config-block-addon.js
+++ b/tests/fixtures/separate-config-block-addon.js
@@ -1,0 +1,24 @@
+/*jshint node:true*/
+/* global require, module */
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function(defaults) {
+  var config = {
+    'some-addon': {
+      'booleanProperty': false,
+      'numericProperty': 17,
+      'stringProperty': 'wow'
+    }
+  };
+
+  var app = new EmberAddon(defaults, config);
+
+  /*
+   This build file specifies the options for the dummy test app of this
+   addon, located in `/tests/dummy`
+   This build file does *not* influence how the addon or the app using it
+   behave. You most likely want to be modifying `./index.js` or app's build fil
+   */
+
+  return app.toTree();
+};

--- a/tests/fixtures/separate-config-block-different-values-addon.js
+++ b/tests/fixtures/separate-config-block-different-values-addon.js
@@ -1,0 +1,24 @@
+/*jshint node:true*/
+/* global require, module */
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function(defaults) {
+  var config = {
+    'some-addon': {
+      'booleanProperty': true,
+      'numericProperty': 42,
+      'stringProperty': 'amazing'
+    }
+  };
+
+  var app = new EmberAddon(defaults, config);
+
+  /*
+   This build file specifies the options for the dummy test app of this
+   addon, located in `/tests/dummy`
+   This build file does *not* influence how the addon or the app using it
+   behave. You most likely want to be modifying `./index.js` or app's build fil
+   */
+
+  return app.toTree();
+};


### PR DESCRIPTION
Following case didn't work. Fix was easy, I added simple test.
```
/*jshint node:true*/
/* global require, module */
var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');

module.exports = function(defaults) {
  var config = {
    'some-addon': {
      'booleanProperty': false,
      'numericProperty': 17,
      'stringProperty': 'wow'
    }
  };

  var app = new EmberAddon(defaults, config);

  /*
   This build file specifies the options for the dummy test app of this
   addon, located in `/tests/dummy`
   This build file does *not* influence how the addon or the app using it
   behave. You most likely want to be modifying `./index.js` or app's build fil
   */

  return app.toTree();
};
```